### PR TITLE
Especificar el tipo de archivo a procesar

### DIFF
--- a/crowdsec/config/acquis.yaml
+++ b/crowdsec/config/acquis.yaml
@@ -1,4 +1,4 @@
 filenames:
-  - /var/log/traefik/*
+  - /var/log/traefik/*.log
 labels:
   type: traefik


### PR DESCRIPTION
Aunque con el asterisco funcionaría bien, es preferible indicarle a CrowdSec que únicamente se deben de procesar los archivos de tipo ".log".