### PR TITLE
Corregir nombre de la instancia

### DIFF
--- a/crowdsec/docker-compose.yml
+++ b/crowdsec/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       GID: ${GID}
       COLLECTIONS: "crowdsecurity/linux crowdsecurity/traefik crowdsecurity/http-cve crowdsecurity/whitelist-good-actors"
-      CUSTOM_HOSTNAME: "Club Celica España"
+      CUSTOM_HOSTNAME: "ClubCelicaSpain"
     security_opt:
       - no-new-privileges=true
 


### PR DESCRIPTION
El nombre no puede contener espacios y como seguramente el carácter "Ñ" tampoco esté permitido, se sustituye por el nombre en inglés.